### PR TITLE
fix : UserFileUtil생성자에서 load제거

### DIFF
--- a/src/main/java/server/util/UserFileUtil.java
+++ b/src/main/java/server/util/UserFileUtil.java
@@ -12,13 +12,11 @@ import server.model.User;
 
 public class UserFileUtil {
 
-    private static final String USER_FILE = "/home/ubuntu/BackEnd/user.txt"; // 절대 경로로 변경
+    private static final String USER_FILE = "/Users/minseok/Documents/3-2/네트워크 프로그래밍/NetworkTeam9/user.txt"; // 절대 경로로 변경
+
     private int nextUserId = 1; // 새로운 유저 ID를 생성할 때 사용
     private final Map<Integer, User> users = new ConcurrentHashMap<>();
-
-    public UserFileUtil() {
-        load(); // 파일에서 유저 데이터를 로드
-    }
+    
 
     // 유저 데이터를 파일에서 로드
     public void load() {

--- a/src/main/java/server/util/UserFileUtil.java
+++ b/src/main/java/server/util/UserFileUtil.java
@@ -12,7 +12,7 @@ import server.model.User;
 
 public class UserFileUtil {
 
-    private static final String USER_FILE = "/Users/minseok/Documents/3-2/네트워크 프로그래밍/NetworkTeam9/user.txt"; // 절대 경로로 변경
+    private static final String USER_FILE = "/home/ubuntu/BackEnd/user.txt"; // 절대 경로로 변경
 
     private int nextUserId = 1; // 새로운 유저 ID를 생성할 때 사용
     private final Map<Integer, User> users = new ConcurrentHashMap<>();


### PR DESCRIPTION
<img width="792" alt="image" src="https://github.com/user-attachments/assets/4e1cbc37-0511-4097-aff6-00da4a0f87ef">

기존 UserFileUtil에서 load를 기본생성자에서 불러 오는 이슈로
<img width="794" alt="image" src="https://github.com/user-attachments/assets/083d5adf-2cba-4f94-b63b-31aee2c9f06f">

다음과 같이 3번의 load가 호출 되었음

수정

