### PR TITLE
[FEAT/#4] 12월 2일 작업 내용

### DIFF
--- a/src/main/java/server/handler/JoinRoomHandler.java
+++ b/src/main/java/server/handler/JoinRoomHandler.java
@@ -76,6 +76,9 @@ public class JoinRoomHandler {
             return;
         }
 
+        // 해당 방에 유저 추가
+        room.addUser(userId, clientSocket);
+
         // 방 입장 성공
         JsonObject data = new JsonObject();
         data.addProperty("roomId", room.getRoomId());

--- a/src/main/java/server/handler/MainHandler.java
+++ b/src/main/java/server/handler/MainHandler.java
@@ -31,28 +31,41 @@ public class MainHandler implements Runnable {
         ) {
             while (true) {
                 String requestJson = reader.readLine();
-                JsonObject request = JsonParser.parseString(requestJson).getAsJsonObject();
-                int messageType = request.get("messageType").getAsInt();
 
-                switch (messageType) {
-                    case 1:
-                        new LoginHandler(userManager).handleLogin(request, writer, clientSocket);
-                        break;
-                    case 2:
-                        new RoomCreationHandler(roomManager).handleCreateRoom(request, writer);
-                        break;
-                    case 3:
-                        new RoomListHandler(roomManager, userManager).handleRoomListRequest(request, writer);
-                        break;
-                    case 4:
-                        new JoinRoomHandler(roomManager, userManager).handleJoinRoomRequest(request, writer,
-                                clientSocket);
-                        break;
-                    default:
-                        JsonObject unknownRequestResponse = new ResponseBuilder(messageType, "9999", "알 수 없는 요청입니다.")
-                                .build();
-                        writer.println(unknownRequestResponse.toString());
-                        break;
+                if (requestJson == null) {
+                    System.out.println("클라이언트 연결이 종료되었습니다.");
+                    break; // 루프 종료
+                }
+
+                try {
+                    JsonObject request = JsonParser.parseString(requestJson).getAsJsonObject();
+                    int messageType = request.get("messageType").getAsInt();
+
+                    switch (messageType) {
+                        case 1:
+                            new LoginHandler(userManager).handleLogin(request, writer, clientSocket);
+                            break;
+                        case 2:
+                            new RoomCreationHandler(roomManager).handleCreateRoom(request, writer, clientSocket);
+                            break;
+                        case 3:
+                            new RoomListHandler(roomManager, userManager).handleRoomListRequest(request, writer);
+                            break;
+                        case 4:
+                            new JoinRoomHandler(roomManager, userManager).handleJoinRoomRequest(request, writer,
+                                    clientSocket);
+                            break;
+                        default:
+                            JsonObject unknownRequestResponse = new ResponseBuilder(0, "9999", "알 수 없는 요청입니다.")
+                                    .build();
+                            writer.println(unknownRequestResponse.toString());
+                            break;
+                    }
+                } catch (Exception e) {
+                    System.out.println("예외 발생: " + e.getMessage());
+                    JsonObject errorResponse = new ResponseBuilder(0, "9998", "잘못된 요청 형식입니다.")
+                            .build();
+                    writer.println(errorResponse.toString());
                 }
             }
         } catch (IOException e) {

--- a/src/main/java/server/handler/RoomCreationHandler.java
+++ b/src/main/java/server/handler/RoomCreationHandler.java
@@ -2,6 +2,7 @@ package server.handler;
 
 import com.google.gson.JsonObject;
 import java.io.PrintWriter;
+import java.net.Socket;
 import server.manager.RoomManager;
 import server.model.Room;
 import server.util.ResponseBuilder;
@@ -14,14 +15,14 @@ public class RoomCreationHandler {
         this.roomManager = roomManager;
     }
 
-    public void handleCreateRoom(JsonObject request, PrintWriter writer) {
+    public void handleCreateRoom(JsonObject request, PrintWriter writer, Socket clientSocket) {
         String roomName = request.get("roomName").getAsString();
         int maxPlayers = request.get("maxPlayers").getAsInt();
         int hostUserId = request.get("hostUserId").getAsInt();
         int quizCount = request.get("quizCount").getAsInt();
 
         // hostUserId가 유효한지 확인
-        if (roomManager.isValidHostUser(hostUserId)) {
+        if (!roomManager.isValidHostUser(hostUserId)) {
             JsonObject errorResponse = new ResponseBuilder(2, "2002", "존재하지 않는 유저 ID입니다.")
                     .build();
             writer.println(errorResponse.toString());
@@ -61,7 +62,7 @@ public class RoomCreationHandler {
         }
 
         // 방 생성
-        Room newRoom = roomManager.createRoom(roomName, maxPlayers, hostUserId, quizCount);
+        Room newRoom = roomManager.createRoom(roomName, maxPlayers, hostUserId, quizCount, clientSocket);
 
         // 성공 응답
         JsonObject data = new JsonObject();

--- a/src/main/java/server/manager/RoomManager.java
+++ b/src/main/java/server/manager/RoomManager.java
@@ -1,5 +1,6 @@
 package server.manager;
 
+import java.net.Socket;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import server.handler.RoomHandler;
@@ -43,12 +44,16 @@ public class RoomManager {
     }
 
     // 방 생성
-    public synchronized Room createRoom(String roomName, int maxPlayers, int hostUserId, int quizCount) {
+    public synchronized Room createRoom(String roomName, int maxPlayers, int hostUserId, int quizCount, Socket socket) {
         RoomHandler roomHandler = new RoomHandler();
         int roomId = nextRoomId++;
         Room room = new Room(roomId, roomName, maxPlayers, hostUserId, quizCount, roomHandler);
         room.startThread(); // Room 내부 쓰레드 시작
         rooms.put(roomId, room);
+        
+        userManager.disconnectFromMainThread(hostUserId); // 메인 쓰레드와의 연결 종료
+        room.addUser(hostUserId, socket);
+
         return room;
     }
 

--- a/src/main/java/testClient/TestClient.java
+++ b/src/main/java/testClient/TestClient.java
@@ -1,0 +1,27 @@
+package testClient;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.Socket;
+
+public class TestClient {
+
+    public static void main(String[] args) {
+        try (Socket socket = new Socket("127.0.0.1", 8080);
+             PrintWriter writer = new PrintWriter(socket.getOutputStream(), true);
+             BufferedReader reader = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+             BufferedReader consoleReader = new BufferedReader(new InputStreamReader(System.in))) {
+
+            String userInput;
+            while ((userInput = consoleReader.readLine()) != null) {
+                writer.println(userInput);  // 서버로 메시지 전송
+                String response = reader.readLine();  // 서버의 응답 읽기
+                System.out.println("서버 응답: " + response);
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+}


### PR DESCRIPTION
- resolved: #4 

---

## 어제 새벽에 작업한 내용들이 담긴 PR입니다.
이후 작업 사항들은 API 단위로 나누어 이슈 파고 해당 브랜치에서 작업해 PR 분리하겠습니다 !

<br>

### 1. 메인 클래스 경로 지정

> 커밋 - fix : 메인 클래스 경로 지정

스프링을 사용하지 않다보니 build 시 메인 클래스를 못잡아서 build.gradle에 메인 클래스를 명시하여 실행 가능한 JAR 파일을 생성하도록 변경하였습니다.

https://github.com/KU-Malang/BackEnd/blob/d8662dc8b59c2c61770f9be0e1d2b44d7e803d0d/build.gradle#L24-L31

<br>

### 2. user.txt 위치 변경 (절대경로 지정)

> 커밋 - fix : 유저 데이터 파일 경로 수정 및 gitignore에 추가

유저 데이터 파일을 절대경로로 읽어오도록 하여 EC2에서 유저 파일 로드에 실패하는 문제를 해결했습니다.

또 위치를 프로젝트 루트로 옮겼는데, resources 폴더 내 파일들은 읽기 전용으로 열리기 때문입니다.

user.txt는 gitignore에 추가했으니 resources에 있던 거 옮겨서 쓰시면 될 것 같습니다!

https://github.com/KU-Malang/BackEnd/blob/d8662dc8b59c2c61770f9be0e1d2b44d7e803d0d/src/main/java/server/util/UserFileUtil.java#L15

<br>

### 3. 외부 라이브러리를 포함한 Fat JAR을 생성하도록 수정

> 커밋 - fix : Shadow 플러그인을 사용하여 gson 라이브러리를 포함한 Fat JAR을 생성하도록 수정

배포 후 테스트 해보려고 요청을 보냈는데 json 관련된 에러가 발생하길래 서치해보니, 1번이랑 비슷한 문제로 build 시 의존성에 추가한 외부 라이브러리를 잡지 못하더라구요.

이 문제를 해결하기 위해 빌드 시 Shadow 플러그인을 사용하여 의존성 추가한 라이브러리들이 포함된 Fat JAR를 생성하도록 만들었습니다.

***노션 계정 공유 페이지에 자세한 빌드 방법 적어놓았습니다 !***

https://github.com/KU-Malang/BackEnd/blob/d8662dc8b59c2c61770f9be0e1d2b44d7e803d0d/build.gradle#L33-L40

<br>

### 4. 방 참여 프로토콜 예외 처리 추가, 예외 발생 시 연결 복구 부분 추가

> 커밋 - feat : 방 참여 프로토콜 구현 완료

방 참여 프로토콜 (4번)에서 예외 처리가 덜 추가된 것 같아서 해당 부분 추가하고, 방에 입장 실패 했을 때 메인 쓰레드와 연결을 복구하는 로직을 추가하였습니다.

https://github.com/KU-Malang/BackEnd/blob/d8662dc8b59c2c61770f9be0e1d2b44d7e803d0d/src/main/java/server/handler/JoinRoomHandler.java#L52-L77

<br>

### 5. 방 생성 예외 처리 추가

> 커밋 - feat : 방 생성 예외 처리 추가

방 이름, 퀴즈 인원 수, 퀴즈 문제 수 유효성 검증하는 로직을 추가했습니다.

https://github.com/KU-Malang/BackEnd/blob/d8662dc8b59c2c61770f9be0e1d2b44d7e803d0d/src/main/java/server/handler/RoomCreationHandler.java#L31-L53

<br>

### 6. 메인 핸들러에 클라이언트 연결 종료를 확인하는 조건문 추가

> 커밋 - feat : 클라이언트 연결 종료 시 NPE 방지를 위한 조건문 추가

저는 netcat이라는 거로 요청을 보냈었는데, 이 친구는 요청을 쏘는 즉시 소켓 연결을 해제하더라구요. 근데 이때 메인 핸들러 부분의 아래 부분에서 requestJson으로 인한 NPE가 발생하길래 예외 처리를 추가해놓았습니다.

https://github.com/KU-Malang/BackEnd/blob/fe2e70bc22f95c79e1fef8bf6c1f09f1212950fb/src/main/java/server/handler/MainHandler.java#L35-L38

<br>

### 7. hostUserId 유효성 검증 로직 오류 수정

> 커밋 - fix : hostUserId 유효성 검증 로직 오류 수정

조건문이 잘못 설정되어있길래 수정했습니다. (!가 안붙어있었어서 유효한 요청이었는데도 불구하고 에러 처리가 되었었음)

https://github.com/KU-Malang/BackEnd/blob/fe2e70bc22f95c79e1fef8bf6c1f09f1212950fb/src/main/java/server/handler/RoomCreationHandler.java#L24-L30

<br>

### 8. 방 생성 및 입장 시 유저 입장 처리 로직 추가

> 커밋 - fix : 방 생성 시 호스트 유저 입장 처리 로직 추가
> 커밋 - fix : 방 입장 시 해당 방에 유저 입장 처리 로직 추가

방 생성 및 입장 시 유저가 입장 처리되는 로직이 구현되어있지 않길래 추가하였습니다. 이제 방 생성된 후 다른 클라이언트로 방 목록을 조회했을 때 인원수가 정상적으로 보입니다.

https://github.com/KU-Malang/BackEnd/blob/fe2e70bc22f95c79e1fef8bf6c1f09f1212950fb/src/main/java/server/manager/RoomManager.java#L46-L58

https://github.com/KU-Malang/BackEnd/blob/fe2e70bc22f95c79e1fef8bf6c1f09f1212950fb/src/main/java/server/handler/JoinRoomHandler.java#L79-L80

<br>

### 9. 테스트용 클라이언트 코드 추가

> 커밋 - feat : 로컬 테스트용 클라이언트 코드 추가

말 그대로 테스트용 클라이언트 코드를 추가하였습니다. 테스트 하실 땐 아래 부분에서 IP만 배포 서버 IP로 바꿔주시면 됩니다. 로컬로 서버 연 후에 로컬 IP로 요청하시면 로컬 환경에서도 테스트 가능합니다.

**배포 서버 IP로 바꾼 후에는 해당 부분 그대로 깃허브에 올라가지 않도록 주의해주세요 !!!**

https://github.com/KU-Malang/BackEnd/blob/fe2e70bc22f95c79e1fef8bf6c1f09f1212950fb/src/main/java/testClient/TestClient.java#L9-L27
