### PR TITLE
fix : userNickname, rating정보 같이 안넘어오던 오류 수정

### DIFF
--- a/src/main/java/server/handler/RoomListHandler.java
+++ b/src/main/java/server/handler/RoomListHandler.java
@@ -48,6 +48,8 @@ public class RoomListHandler implements RequestHandler {
 
         // 응답 생성
         JsonObject data = new JsonObject();
+        data.addProperty("nickname", user.getNickname());
+        data.addProperty("rating", user.getRating());
         data.add("rooms", roomsArray);
 
         JsonObject successResponse = new ResponseBuilder(3, "success", "방 목록 조회 성공")


### PR DESCRIPTION
### 기존 Response (nickname, rating이 빠져있음)
```
{
  "messageType": 3,
  "status": "success",
  "message": "성공",
  "data": {
    "rooms": [
      {
        "roomId": 1,
        "roomName": "건대생들 고고",
        "quizCount": 40,
        "currentPlayers": 8,
        "maxPlayers": 5
      },
    ]
  }
}
```

### 수정된 Response 

```
{
  "messageType": 3,
  "status": "success",
  "message": "성공",
  "data": {
    "nickname": "이수",
    "rating": 2813,
    "rooms": [
      {
        "roomId": 1,
        "roomName": "건대생들 고고",
        "quizCount": 40,
        "currentPlayers": 8,
        "maxPlayers": 5
      },
    ]
  }
}
```
