### PR TITLE
#11:  방 생성 시 방 참여는 클라에서 처리

### DIFF
--- a/src/main/java/server/handler/RoomCreationHandler.java
+++ b/src/main/java/server/handler/RoomCreationHandler.java
@@ -64,7 +64,6 @@ public class RoomCreationHandler implements RequestHandler {
 
         // 방 생성
         Room newRoom = roomManager.createRoom(roomName, maxPlayers, hostUserId, quizCount);
-        newRoom.addUser(hostUserId, writer);
 
 
 


### PR DESCRIPTION
<img width="770" alt="image" src="https://github.com/user-attachments/assets/69b01517-20f7-40af-8489-a6e69919bd42">

방 생성한 방장은 방 입장까지 진행시키려고 하였으나, 그 부분이 클라이언트에서 방입장 프로토콜도 동시에 전송 하여서

방 입장은 서버에서 따로 시키지 않도록 변경

<img width="777" alt="image" src="https://github.com/user-attachments/assets/574ab674-08c8-499f-ae30-e29502ac1606">
