### PR TITLE
[FEAT/#13] 클라이언트 연결 종료 시 로그인되어 있던 유저 로그아웃 처리 로직 추가

### DIFF
--- a/src/main/java/server/GameServer.java
+++ b/src/main/java/server/GameServer.java
@@ -30,7 +30,7 @@ public class GameServer {
 
             while (true) {
                 Socket clientSocket = serverSocket.accept();
-                threadPool.execute(new UserThread(clientSocket, mainHandler)); // MainHandler 공유
+                threadPool.execute(new UserThread(clientSocket, mainHandler, userManager)); // MainHandler 공유
             }
         } catch (IOException e) {
             e.printStackTrace();

--- a/src/main/java/server/GameServer.java
+++ b/src/main/java/server/GameServer.java
@@ -28,6 +28,19 @@ public class GameServer {
             System.out.println("유저 파일을 읽어옵니다...");
             userFileUtil.load();
 
+            // 안전한 종료를 위한 Shutdown Hook 추가
+            Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+                System.out.println("서버를 종료합니다. 모든 자원을 해제합니다...");
+                threadPool.shutdown(); // 스레드 풀 종료
+                try {
+                    if (!serverSocket.isClosed()) {
+                        serverSocket.close(); // 서버 소켓 닫기
+                    }
+                } catch (IOException e) {
+                    System.out.println("서버 소켓 종료 중 예외 발생: " + e.getMessage());
+                }
+            }));
+
             while (true) {
                 Socket clientSocket = serverSocket.accept();
                 threadPool.execute(new UserThread(clientSocket, mainHandler, userManager)); // MainHandler 공유

--- a/src/main/java/server/RoomThread.java
+++ b/src/main/java/server/RoomThread.java
@@ -1,9 +1,8 @@
 package server;
 
-import server.model.Room;
-
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
+import server.model.Room;
 
 public class RoomThread implements Runnable {
 
@@ -33,6 +32,7 @@ public class RoomThread implements Runnable {
 
     public void stopThread() {
         running = false;
-        taskQueue.offer(() -> {}); // 큐를 깨워서 쓰레드 종료
+        taskQueue.offer(() -> {
+        }); // 큐를 깨워서 쓰레드 종료
     }
 }

--- a/src/main/java/server/UserThread.java
+++ b/src/main/java/server/UserThread.java
@@ -6,17 +6,20 @@ import java.io.InputStreamReader;
 import java.io.PrintWriter;
 import java.net.Socket;
 import server.handler.MainHandler;
+import server.manager.UserManager;
 
 public class UserThread implements Runnable {
 
     private final Socket socket;
     private final MainHandler mainHandler; // 공유된 MainHandler 사용
+    private final UserManager userManager; // UserManager 추가
     private volatile boolean running = true; // 쓰레드 상태 관리
     private int userId = 0; // 로그인되지 않은 상태의 기본값
 
-    public UserThread(Socket socket, MainHandler mainHandler) {
+    public UserThread(Socket socket, MainHandler mainHandler, UserManager userManager) {
         this.socket = socket;
         this.mainHandler = mainHandler;
+        this.userManager = userManager;
     }
 
     @Override
@@ -52,11 +55,22 @@ public class UserThread implements Runnable {
 
     private void cleanup() {
         System.out.println("유저 쓰레드 종료");
+
+        // userId가 설정된 경우 로그아웃 처리
+        if (userId != 0) {
+            userManager.logoutUser(userId);
+            System.out.println("유저 ID: " + userId + "의 연결이 종료되었습니다. 로그아웃 처리 완료.");
+        }
+
         stopThread();
     }
 
     // 로그인 성공 시 UserThread에 유저 ID를 설정하는 메서드 추가
     public void setUserId(int userId) {
         this.userId = userId;
+    }
+
+    public int getUserId() {
+        return userId;
     }
 }

--- a/src/main/java/server/UserThread.java
+++ b/src/main/java/server/UserThread.java
@@ -12,6 +12,7 @@ public class UserThread implements Runnable {
     private final Socket socket;
     private final MainHandler mainHandler; // 공유된 MainHandler 사용
     private volatile boolean running = true; // 쓰레드 상태 관리
+    private int userId = 0; // 로그인되지 않은 상태의 기본값
 
     public UserThread(Socket socket, MainHandler mainHandler) {
         this.socket = socket;
@@ -31,7 +32,7 @@ public class UserThread implements Runnable {
                 }
 
                 System.out.println("요청 처리 중: " + requestJson);
-                mainHandler.mainHandler(requestJson, writer); // 요청 처리
+                mainHandler.mainHandler(requestJson, writer, this); // UserThread 인스턴스를 전달
             }
         } catch (IOException e) {
             System.out.println("클라이언트 연결 종료: " + e.getMessage());
@@ -52,5 +53,10 @@ public class UserThread implements Runnable {
     private void cleanup() {
         System.out.println("유저 쓰레드 종료");
         stopThread();
+    }
+
+    // 로그인 성공 시 UserThread에 유저 ID를 설정하는 메서드 추가
+    public void setUserId(int userId) {
+        this.userId = userId;
     }
 }

--- a/src/main/java/server/handler/AnswerSubmissionHandler.java
+++ b/src/main/java/server/handler/AnswerSubmissionHandler.java
@@ -1,15 +1,12 @@
 package server.handler;
 
-
 import com.google.gson.JsonObject;
 import java.io.PrintWriter;
-import java.net.Socket;
-
-import server.model.Room;
 import server.manager.RoomManager;
+import server.model.Room;
 import server.util.ResponseBuilder;
 
-public class AnswerSubmissionHandler implements RequestHandler  {
+public class AnswerSubmissionHandler implements RequestHandler {
 
     private final RoomManager roomManager;
 
@@ -17,9 +14,7 @@ public class AnswerSubmissionHandler implements RequestHandler  {
         this.roomManager = roomManager;
     }
 
-
     @Override
-
     public void handleRequest(JsonObject request, PrintWriter writer) {
         int userId = request.get("userId").getAsInt();
         int roomId = request.get("roomId").getAsInt();

--- a/src/main/java/server/handler/JoinRoomHandler.java
+++ b/src/main/java/server/handler/JoinRoomHandler.java
@@ -2,13 +2,12 @@ package server.handler;
 
 import com.google.gson.JsonObject;
 import java.io.PrintWriter;
-import java.net.Socket;
 import server.manager.RoomManager;
 import server.manager.UserManager;
 import server.model.Room;
 import server.util.ResponseBuilder;
 
-public class JoinRoomHandler implements RequestHandler  {
+public class JoinRoomHandler implements RequestHandler {
 
     private final RoomManager roomManager;
     private final UserManager userManager;
@@ -50,17 +49,15 @@ public class JoinRoomHandler implements RequestHandler  {
             return;
         }
 
-
-
         // 방 입장 실패 - 이미 게임이 진행 중인 방인 경우
         if (room.isGameInProgress()) {
             JsonObject errorResponse = new ResponseBuilder(4, "4004", "이미 게임이 진행 중인 방입니다.")
                     .build();
             writer.println(errorResponse.toString());
 
-
             return;
         }
+
         // 방 입장 실패 - 인원이 다 찼거나 이미 참가중인 방인 경우
         if (!room.addUser(userId, writer)) {
             JsonObject errorResponse = new ResponseBuilder(4, "4003", "인원이 다 찼거나 이미 참가중인 방입니다.")
@@ -69,7 +66,6 @@ public class JoinRoomHandler implements RequestHandler  {
 
             return;
         }
-
 
         // 방 입장 성공
         JsonObject data = new JsonObject();
@@ -82,6 +78,4 @@ public class JoinRoomHandler implements RequestHandler  {
                 .build();
         writer.println(successResponse.toString());
     }
-
-
 }

--- a/src/main/java/server/handler/LoginHandler.java
+++ b/src/main/java/server/handler/LoginHandler.java
@@ -2,7 +2,6 @@ package server.handler;
 
 import com.google.gson.JsonObject;
 import java.io.PrintWriter;
-import java.net.Socket;
 import server.manager.UserManager;
 import server.model.User;
 import server.util.ResponseBuilder;
@@ -16,7 +15,7 @@ public class LoginHandler implements RequestHandler {
     }
 
     @Override
-    public void handleRequest(JsonObject request, PrintWriter writer) {
+    public int handleRequest(JsonObject request, PrintWriter writer) {
         String nickname = request.get("nickname").getAsString();
         String password = request.get("password").getAsString();
 
@@ -24,7 +23,7 @@ public class LoginHandler implements RequestHandler {
             JsonObject errorResponse = new ResponseBuilder(1, "1001", "유저 아이디가 10글자를 초과합니다.")
                     .build();
             writer.println(errorResponse.toString());
-            return;
+            return 0;
         }
 
         // 유저 아이디가 없는 경우 -> 회원가입 진행
@@ -40,7 +39,7 @@ public class LoginHandler implements RequestHandler {
             JsonObject errorResponse = new ResponseBuilder(1, "1002", "비밀번호가 일치하지 않습니다.")
                     .build();
             writer.println(errorResponse.toString());
-            return;
+            return 0;
         }
 
         // 이미 로그인 중인 경우
@@ -48,19 +47,20 @@ public class LoginHandler implements RequestHandler {
             JsonObject errorResponse = new ResponseBuilder(1, "1003", "이미 로그인 중인 유저입니다.")
                     .build();
             writer.println(errorResponse.toString());
-            return;
+            return 0;
         }
 
         userManager.loginUser(currentUser.getUserId(), writer);
-
 
         // 성공 응답
         JsonObject data = new JsonObject();
         data.addProperty("userId", currentUser.getUserId());
 
-        JsonObject successResponse = new ResponseBuilder(1, "success", "로그인 성공")
+        JsonObject successResponse = new ResponseBuilder(1, "success", "성공")
                 .withData(data)
                 .build();
         writer.println(successResponse.toString());
+
+        return currentUser.getUserId(); // 성공 시 유저 ID 반환
     }
 }

--- a/src/main/java/server/handler/LoginHandler.java
+++ b/src/main/java/server/handler/LoginHandler.java
@@ -2,11 +2,12 @@ package server.handler;
 
 import com.google.gson.JsonObject;
 import java.io.PrintWriter;
+import server.UserThread;
 import server.manager.UserManager;
 import server.model.User;
 import server.util.ResponseBuilder;
 
-public class LoginHandler implements RequestHandler {
+public class LoginHandler {
 
     private final UserManager userManager; // UserManager 주입
 
@@ -14,8 +15,7 @@ public class LoginHandler implements RequestHandler {
         this.userManager = userManager;
     }
 
-    @Override
-    public int handleRequest(JsonObject request, PrintWriter writer) {
+    public void handleRequest(JsonObject request, PrintWriter writer, UserThread userThread) {
         String nickname = request.get("nickname").getAsString();
         String password = request.get("password").getAsString();
 
@@ -23,7 +23,7 @@ public class LoginHandler implements RequestHandler {
             JsonObject errorResponse = new ResponseBuilder(1, "1001", "유저 아이디가 10글자를 초과합니다.")
                     .build();
             writer.println(errorResponse.toString());
-            return 0;
+            return;
         }
 
         // 유저 아이디가 없는 경우 -> 회원가입 진행
@@ -39,7 +39,7 @@ public class LoginHandler implements RequestHandler {
             JsonObject errorResponse = new ResponseBuilder(1, "1002", "비밀번호가 일치하지 않습니다.")
                     .build();
             writer.println(errorResponse.toString());
-            return 0;
+            return;
         }
 
         // 이미 로그인 중인 경우
@@ -47,10 +47,13 @@ public class LoginHandler implements RequestHandler {
             JsonObject errorResponse = new ResponseBuilder(1, "1003", "이미 로그인 중인 유저입니다.")
                     .build();
             writer.println(errorResponse.toString());
-            return 0;
+            return;
         }
 
         userManager.loginUser(currentUser.getUserId(), writer);
+
+        // 로그인 성공 시 UserThread에 userId 할당
+        userThread.setUserId(currentUser.getUserId());
 
         // 성공 응답
         JsonObject data = new JsonObject();
@@ -60,7 +63,5 @@ public class LoginHandler implements RequestHandler {
                 .withData(data)
                 .build();
         writer.println(successResponse.toString());
-
-        return currentUser.getUserId(); // 성공 시 유저 ID 반환
     }
 }

--- a/src/main/java/server/handler/MainHandler.java
+++ b/src/main/java/server/handler/MainHandler.java
@@ -3,7 +3,7 @@ package server.handler;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import java.io.PrintWriter;
-import java.net.Socket;
+import server.UserThread;
 import server.manager.RoomManager;
 import server.manager.UserManager;
 import server.util.ResponseBuilder;
@@ -18,14 +18,19 @@ public class MainHandler {
         this.roomManager = roomManager;
     }
 
-    public void mainHandler(String requestJson, PrintWriter writer) {
+    public void mainHandler(String requestJson, PrintWriter writer, UserThread userThread) {
         try {
             JsonObject request = JsonParser.parseString(requestJson).getAsJsonObject();
             int messageType = request.get("messageType").getAsInt();
 
             switch (messageType) {
                 case 1:
-                    new LoginHandler(userManager).handleRequest(request, writer);
+                    int userId = new LoginHandler(userManager).handleRequest(request, writer);
+
+                    if (userId != -1) {
+                        userThread.setUserId(userId); // 로그인 성공 시 UserThread에 userId 할당
+                    }
+
                     break;
                 case 2:
                     new RoomCreationHandler(roomManager).handleRequest(request, writer);
@@ -44,7 +49,7 @@ public class MainHandler {
                     break;
                 case 7: // 정답 제출
                     //TODO- 정답 제출
-                    new AnswerSubmissionHandler(roomManager).handleRequest(request,writer);
+                    new AnswerSubmissionHandler(roomManager).handleRequest(request, writer);
                     break;
                 case 8: // 오답 제출
                     //TODO- 오답 제출

--- a/src/main/java/server/handler/MainHandler.java
+++ b/src/main/java/server/handler/MainHandler.java
@@ -25,12 +25,7 @@ public class MainHandler {
 
             switch (messageType) {
                 case 1:
-                    int userId = new LoginHandler(userManager).handleRequest(request, writer);
-
-                    if (userId != -1) {
-                        userThread.setUserId(userId); // 로그인 성공 시 UserThread에 userId 할당
-                    }
-
+                    new LoginHandler(userManager).handleRequest(request, writer, userThread);
                     break;
                 case 2:
                     new RoomCreationHandler(roomManager).handleRequest(request, writer);

--- a/src/main/java/server/handler/RequestHandler.java
+++ b/src/main/java/server/handler/RequestHandler.java
@@ -1,9 +1,7 @@
 package server.handler;
 
 import com.google.gson.JsonObject;
-
 import java.io.PrintWriter;
-import java.net.Socket;
 
 public interface RequestHandler {
 

--- a/src/main/java/server/handler/RoomCreationHandler.java
+++ b/src/main/java/server/handler/RoomCreationHandler.java
@@ -2,7 +2,6 @@ package server.handler;
 
 import com.google.gson.JsonObject;
 import java.io.PrintWriter;
-import java.net.Socket;
 import server.manager.RoomManager;
 import server.model.Room;
 import server.util.ResponseBuilder;
@@ -65,8 +64,6 @@ public class RoomCreationHandler implements RequestHandler {
         // 방 생성
         Room newRoom = roomManager.createRoom(roomName, maxPlayers, hostUserId, quizCount);
         newRoom.addUser(hostUserId, writer);
-
-
 
         // 성공 응답
         JsonObject data = new JsonObject();

--- a/src/main/java/server/handler/RoomListHandler.java
+++ b/src/main/java/server/handler/RoomListHandler.java
@@ -25,6 +25,7 @@ public class RoomListHandler implements RequestHandler {
         JsonArray roomsArray = new JsonArray();
 
         int userId = request.get("userId").getAsInt();
+
         // 유저 정보 가져오기
         User user = userManager.getUserById(userId);
 

--- a/src/main/java/server/manager/RoomManager.java
+++ b/src/main/java/server/manager/RoomManager.java
@@ -1,6 +1,5 @@
 package server.manager;
 
-import java.net.Socket;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import server.model.Room;
@@ -45,10 +44,9 @@ public class RoomManager {
     // 방 생성
     public synchronized Room createRoom(String roomName, int maxPlayers, int hostUserId, int quizCount) {
         int roomId = nextRoomId++;
-        Room room = new Room(roomId, roomName, maxPlayers, hostUserId, quizCount,userManager);
+        Room room = new Room(roomId, roomName, maxPlayers, hostUserId, quizCount, userManager);
         room.startThread(); // Room 내부 쓰레드 시작
         rooms.put(roomId, room);
-        
 
         return room;
     }
@@ -63,8 +61,6 @@ public class RoomManager {
             System.out.println("방 ID " + roomId + "를 찾을 수 없습니다.");
         }
     }
-
-
 
     // 전체 방 조회
     public Map<Integer, Room> getAllRooms() {

--- a/src/main/java/server/manager/UserManager.java
+++ b/src/main/java/server/manager/UserManager.java
@@ -1,7 +1,6 @@
 package server.manager;
 
 import java.io.PrintWriter;
-import java.net.Socket;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import server.model.User;
@@ -14,13 +13,13 @@ public class UserManager {
     private final UserFileUtil userFileUtil; // 유저 파일 유틸리티
 
     public UserManager(UserFileUtil userFileUtil) {
-        this.userFileUtil= userFileUtil;
+        this.userFileUtil = userFileUtil;
         this.users = new ConcurrentHashMap<>(userFileUtil.getUsers()); // 파일에서 유저 데이터 로드
     }
 
     // 유저 로그인
     public void loginUser(int userId, PrintWriter writer) {
-        loggedInUsers.put(userId,writer ); // 유저를 로그인 상태로 추가
+        loggedInUsers.put(userId, writer); // 유저를 로그인 상태로 추가
     }
 
     // 유저 로그아웃

--- a/src/main/java/server/model/Room.java
+++ b/src/main/java/server/model/Room.java
@@ -1,10 +1,8 @@
 package server.model;
 
 import java.io.PrintWriter;
-import java.net.Socket;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-
 import server.RoomThread;
 import server.manager.UserManager;
 
@@ -30,9 +28,10 @@ public class Room {
         this.maxPlayers = maxPlayers;
         this.hostUserId = hostUserId;
         this.quizCount = quizCount;
-        this.roomThread= new RoomThread(this);
+        this.roomThread = new RoomThread(this);
         this.userManager = userManager;
     }
+
     // 방 쓰레드 시작
     public void startThread() {
         new Thread(roomThread).start();
@@ -43,21 +42,16 @@ public class Room {
         roomThread.stopThread();
     }
 
-
     // 점수 증가 메서드
     public synchronized void incrementScore(int userId) {
         userRating.put(userId, userRating.getOrDefault(userId, 0) + 1);
         System.out.println("유저 " + userId + "의 점수가 증가했습니다: " + userRating.get(userId));
     }
 
-
-
     // 작업 추가
     public void addTask(Runnable task) {
         roomThread.addTask(task);
     }
-
-
 
     // 유저 추가
     public synchronized boolean addUser(int userId, PrintWriter writer) {
@@ -65,12 +59,10 @@ public class Room {
             return false;
         }
         userWriter.put(userId, writer);
-        int addUserRating=userManager.getUserById(userId).getRating();
+        int addUserRating = userManager.getUserById(userId).getRating();
         this.userRating.put(userId, addUserRating);
         return true;
     }
-
-
 
     // 특정 유저에게 메시지 전송
     public synchronized void sendMessageToUser(int userId, String message) {
@@ -124,5 +116,4 @@ public class Room {
     public Map<Integer, PrintWriter> getUserWriter() {
         return userWriter;
     }
-
 }

--- a/src/main/java/server/util/UserFileUtil.java
+++ b/src/main/java/server/util/UserFileUtil.java
@@ -59,7 +59,8 @@ public class UserFileUtil {
 
     public synchronized void save(User user) {
         try (BufferedWriter writer = new BufferedWriter(new FileWriter(USER_FILE, true))) { // append = true
-            writer.write(user.getUserId() + " " + user.getNickname() + " " + user.getPassword() + " " + user.getRating());
+            writer.write(
+                    user.getUserId() + " " + user.getNickname() + " " + user.getPassword() + " " + user.getRating());
             writer.newLine();
         } catch (IOException e) {
             e.printStackTrace();


### PR DESCRIPTION
- resolved: #13 

---

제가 저장할 때마다 자동으로 코드 스타일이 맞춰지게 설정되어 있어서 관련되지 않은 부분까지 많이 수정되었는데,

`GameServer`, `UserThread`, `LoginHandler`, `MainHandler` 위주로 봐주시면 됩니다.

<br>

`MainHandler`에서는 mainHandler 메서드가 추가로 `UserThread`를 파라미터로 받아 `LoginHandler`로 넘겨주고,

`LoginHandler`에서는 로그인 성공 시 기본값으로 설정되어 있던 `UserThread`의 `UserId`에 로그인된 유저의 ID를 할당해주는 구조입니다.

<br>

추가로 `GameServer(main)`에서 서버 종료 시 메모리가 안전하게 해제될 수 있도록 Shutdown Hook을 추가하였습니다.