### PR TITLE
[FEAT/#16] 퀴즈 주제 선택 API 구현

### DIFF
--- a/src/main/java/server/enums/Topic.java
+++ b/src/main/java/server/enums/Topic.java
@@ -1,0 +1,38 @@
+package server.enums;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public enum Topic {
+
+    CULTURE("CULTURE"),
+    HISTORY("HISTORY"),
+    CURRENT_AFFAIRS("CURRENT_AFFAIRS"),
+    GEOGRAPHY("GEOGRAPHY"),
+    COMPUTER("COMPUTER"),
+    GENERAL_KNOWLEDGE("GENERAL_KNOWLEDGE"),
+
+    ;
+
+    private final String value;
+
+    private static final Map<String, Topic> TOPIC_MAP = new HashMap<>();
+
+    static {
+        for (Topic topic : Topic.values()) {
+            TOPIC_MAP.put(topic.getValue(), topic);
+        }
+    }
+
+    Topic(String value) {
+        this.value = value;
+    }
+
+    public static Topic fromValue(String value) {
+        return TOPIC_MAP.get(value);
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/server/handler/MainHandler.java
+++ b/src/main/java/server/handler/MainHandler.java
@@ -36,8 +36,8 @@ public class MainHandler {
                 case 4:
                     new JoinRoomHandler(roomManager, userManager).handleRequest(request, writer);
                     break;
-                case 5: // 퀴즈 주제 선택
-                    //TODO- 퀴즈 주제 선택
+                case 5:
+                    new TopicSelectionHandler(roomManager).handleRequest(request, writer);
                     break;
                 case 6: // 문제 출제
                     //TODO- 문제 출제

--- a/src/main/java/server/handler/TopicSelectionHandler.java
+++ b/src/main/java/server/handler/TopicSelectionHandler.java
@@ -38,7 +38,7 @@ public class TopicSelectionHandler implements RequestHandler {
             return;
         }
 
-        // 방 입장 성공
+        // 주제 선택 성공
         JsonObject data = new JsonObject();
         data.addProperty("topic", topic);
 

--- a/src/main/java/server/handler/TopicSelectionHandler.java
+++ b/src/main/java/server/handler/TopicSelectionHandler.java
@@ -1,0 +1,50 @@
+package server.handler;
+
+import com.google.gson.JsonObject;
+import java.io.PrintWriter;
+import server.enums.Topic;
+import server.manager.RoomManager;
+import server.model.Room;
+import server.util.ResponseBuilder;
+
+public class TopicSelectionHandler implements RequestHandler {
+
+    private final RoomManager roomManager;
+
+    public TopicSelectionHandler(RoomManager roomManager) {
+        this.roomManager = roomManager;
+    }
+
+    @Override
+    public void handleRequest(JsonObject request, PrintWriter writer) {
+        int roomId = request.get("roomId").getAsInt();
+        String topic = request.get("topic").getAsString();
+
+        Room room = roomManager.getRoom(roomId);
+
+        // 방이 존재하지 않는 경우
+        if (room == null) {
+            JsonObject errorResponse = new ResponseBuilder(5, "5001", "존재하지 않는 방 ID입니다.")
+                    .build();
+            writer.println(errorResponse.toString());
+            return;
+        }
+
+        // 주제가 존재하지 않는 경우
+        if (Topic.fromValue(topic) == null) {
+            JsonObject errorResponse = new ResponseBuilder(5, "5002", "존재하지 않는 주제입니다.")
+                    .build();
+            writer.println(errorResponse.toString());
+            return;
+        }
+
+        // 방 입장 성공
+        JsonObject data = new JsonObject();
+        data.addProperty("topic", topic);
+
+        JsonObject successResponse = new ResponseBuilder(5, "success", "성공")
+                .withData(data)
+                .build();
+        room.broadcastMessage(successResponse.toString());
+    }
+}


### PR DESCRIPTION
- resolved: #16 

---

- Topic Enum을 추가했습니다. 아래 코드는 Enum에 존재하는 String인지, 즉 클라이언트 요청 값이 올바른 주제인지 확인하는 코드입니다. 존재할 경우 해당 Topic을, 존재하지 않을 경우 null을 반환합니다.
 
https://github.com/KU-Malang/BackEnd/blob/34b85bc165f25f2e6a609c986b820eee951ccd91/src/main/java/server/enums/Topic.java#L19-L33

<br>

- 선택된 퀴즈 주제를 방 안 모든 유저에게 브로드캐스트하는 코드입니다. 해당 부분 참고하시어 4번 프로토콜(방 참여)도 응답을 브로드캐스트하게끔 수정해 주시면 좋을 것 같습니다.

https://github.com/KU-Malang/BackEnd/blob/34b85bc165f25f2e6a609c986b820eee951ccd91/src/main/java/server/handler/TopicSelectionHandler.java#L41-L48