### PR TITLE
feat : 다중 클라이언트를 위해 ClientTest클래스 추가 생성 및, response 받은 쓰레드와 입력하는 쓰레드 분리

### DIFF
--- a/src/main/java/server/model/Room.java
+++ b/src/main/java/server/model/Room.java
@@ -75,6 +75,8 @@ public class Room {
     // 특정 유저에게 메시지 전송
     public synchronized void sendMessageToUser(int userId, String message) {
         userWriter.get(userId).println(message);
+        userWriter.get(userId).flush(); // 버퍼를 비워줌
+
     }
 
     // 모든 유저에게 메시지 브로드캐스트

--- a/src/main/java/testClient/InputThread.java
+++ b/src/main/java/testClient/InputThread.java
@@ -1,0 +1,36 @@
+package testClient;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.net.Socket;
+
+// 서버로부터 오는 메시지를 처리하는 InputThread
+class InputThread extends Thread {
+    private Socket socket;
+    private BufferedReader serverReader;
+
+    public InputThread(Socket socket, BufferedReader serverReader) {
+        this.socket = socket;
+        this.serverReader = serverReader;
+    }
+
+    @Override
+    public void run() {
+        try {
+            String messageFromServer;
+            while ((messageFromServer = serverReader.readLine()) != null) {
+                System.out.println("서버 응답: " + messageFromServer);
+            }
+        } catch (IOException e) {
+            System.out.println("서버와의 연결이 종료되었습니다: " + e.getMessage());
+        } finally {
+            // 자원 정리
+            try {
+                if (serverReader != null) serverReader.close();
+                if (socket != null) socket.close();
+            } catch (IOException e) {
+                System.out.println("InputThread 자원 정리 중 오류 발생: " + e.getMessage());
+            }
+        }
+    }
+}

--- a/src/main/java/testClient/TestClient2.java
+++ b/src/main/java/testClient/TestClient2.java
@@ -1,0 +1,59 @@
+package testClient;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.Socket;
+
+public class TestClient2 {
+
+    public static void main(String[] args) {
+        Socket socket = null;
+        PrintWriter writer = null;
+        BufferedReader consoleReader = null;
+        boolean endFlag = false;
+
+        try {
+            // 서버 연결
+            socket = new Socket("127.0.0.1", 8080);
+
+            // 입출력 스트림 초기화
+            writer = new PrintWriter(socket.getOutputStream(), true);
+            BufferedReader serverReader = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+            consoleReader = new BufferedReader(new InputStreamReader(System.in));
+
+            // 서버 메시지 수신용 InputThread 생성 및 시작
+            InputThread inputThread = new InputThread(socket, serverReader);
+            inputThread.start();
+
+            System.out.println("서버와 연결되었습니다. 메시지를 입력하세요 ('quit' 입력 시 종료):");
+
+            // 사용자 입력 처리
+            String userInput;
+            while ((userInput = consoleReader.readLine()) != null) {
+                writer.println(userInput); // 서버로 메시지 전송
+                writer.flush(); // 버퍼 비우기
+
+                if ("quit".equalsIgnoreCase(userInput)) {
+                    endFlag = true; // 종료 플래그 설정
+                    break;
+                }
+            }
+
+        } catch (IOException e) {
+            System.out.println("클라이언트 오류 발생: " + e.getMessage());
+        } finally {
+            // 자원 정리
+            try {
+                if (consoleReader != null) consoleReader.close();
+                if (writer != null) writer.close();
+                if (socket != null) socket.close();
+            } catch (IOException e) {
+                System.out.println("자원 정리 중 오류 발생: " + e.getMessage());
+            }
+            System.out.println("클라이언트가 종료되었습니다.");
+        }
+    }
+}
+

--- a/src/main/java/testClient/TestClient3.java
+++ b/src/main/java/testClient/TestClient3.java
@@ -1,0 +1,59 @@
+package testClient;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.PrintWriter;
+import java.net.Socket;
+
+public class TestClient3 {
+
+    public static void main(String[] args) {
+        Socket socket = null;
+        PrintWriter writer = null;
+        BufferedReader consoleReader = null;
+        boolean endFlag = false;
+
+        try {
+            // 서버 연결
+            socket = new Socket("127.0.0.1", 8080);
+
+            // 입출력 스트림 초기화
+            writer = new PrintWriter(socket.getOutputStream(), true);
+            BufferedReader serverReader = new BufferedReader(new InputStreamReader(socket.getInputStream()));
+            consoleReader = new BufferedReader(new InputStreamReader(System.in));
+
+            // 서버 메시지 수신용 InputThread 생성 및 시작
+            InputThread inputThread = new InputThread(socket, serverReader);
+            inputThread.start();
+
+            System.out.println("서버와 연결되었습니다. 메시지를 입력하세요 ('quit' 입력 시 종료):");
+
+            // 사용자 입력 처리
+            String userInput;
+            while ((userInput = consoleReader.readLine()) != null) {
+                writer.println(userInput); // 서버로 메시지 전송
+                writer.flush(); // 버퍼 비우기
+
+                if ("quit".equalsIgnoreCase(userInput)) {
+                    endFlag = true; // 종료 플래그 설정
+                    break;
+                }
+            }
+
+        } catch (IOException e) {
+            System.out.println("클라이언트 오류 발생: " + e.getMessage());
+        } finally {
+            // 자원 정리
+            try {
+                if (consoleReader != null) consoleReader.close();
+                if (writer != null) writer.close();
+                if (socket != null) socket.close();
+            } catch (IOException e) {
+                System.out.println("자원 정리 중 오류 발생: " + e.getMessage());
+            }
+            System.out.println("클라이언트가 종료되었습니다.");
+        }
+    }
+}
+


### PR DESCRIPTION
현재 TestClient는 요청을 보냈을 시에만 response를 받는 구조여서 broadcast와 같이 아무 요청도 보내지 않았을 시에는 response을 받지 못하는 상황입니다.

`TestClient2` 클래스는 서버 메시지 수신용 `InputThread` 를 이용하여 요청을 보내지 않았을 시에도 response(broadcast와 같은 상황)을  받을 수 있도록 하였습니다
https://github.com/KU-Malang/BackEnd/blob/3b638fe30e8103aa83dafc3d10caf2aeed1c9a46/src/main/java/testClient/InputThread.java#L8-L36


`TestClient3`은 `TestClient2`와 동시에 실행시켜서 다중 클라이언트 환경에서 Test하기 위해서 하나 더 만들었습니다.