### PR TITLE
fix : 유저 로그인 시 이미 존재하는 유저 정보임에도 불구하고 회원가입으로 인식하는 오류 수정

### DIFF
--- a/src/main/java/server/GameServer.java
+++ b/src/main/java/server/GameServer.java
@@ -25,9 +25,6 @@ public class GameServer {
         try (ServerSocket serverSocket = new ServerSocket(PORT)) {
             System.out.println("서버가 시작되었습니다. 포트: " + PORT);
 
-            System.out.println("유저 파일을 읽어옵니다...");
-            userFileUtil.load();
-
             // 안전한 종료를 위한 Shutdown Hook 추가
             Runtime.getRuntime().addShutdownHook(new Thread(() -> {
                 System.out.println("서버를 종료합니다. 모든 자원을 해제합니다...");

--- a/src/main/java/server/manager/UserManager.java
+++ b/src/main/java/server/manager/UserManager.java
@@ -14,6 +14,7 @@ public class UserManager {
 
     public UserManager(UserFileUtil userFileUtil) {
         this.userFileUtil = userFileUtil;
+        userFileUtil.load();
         this.users = new ConcurrentHashMap<>(userFileUtil.getUsers()); // 파일에서 유저 데이터 로드
     }
 

--- a/src/main/java/server/util/UserFileUtil.java
+++ b/src/main/java/server/util/UserFileUtil.java
@@ -16,7 +16,6 @@ public class UserFileUtil {
 
     private int nextUserId = 1; // 새로운 유저 ID를 생성할 때 사용
     private final Map<Integer, User> users = new ConcurrentHashMap<>();
-    
 
     // 유저 데이터를 파일에서 로드
     public void load() {


### PR DESCRIPTION
GameServer의 메인 메서드에서 load() 메서드가 실행되는 부분은 이미 UserManager에 UserFileUtil이 주입되고 난 이후입니다.

즉 UserManager의 users에는 빈 값이 들어가고 있었다고 보시면 됩니다.

이에 UserManager 생성자 블록 안으로 load() 메서드의 실행 위치를 변경하였습니다.